### PR TITLE
email validator should return true for null, undefined and empty values

### DIFF
--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -1,4 +1,7 @@
 export default value => {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return true
+  }
   let reg = /(^$|^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$)/
   return reg.test(value)
 }

--- a/src/validators/sameAs.js
+++ b/src/validators/sameAs.js
@@ -1,8 +1,4 @@
 export default equalTo => function (value, parentVm) {
-  if (value === null || value === undefined || value === '') {
-    return true
-  }
-
   const compareTo = typeof equalTo === 'function'
     ? equalTo.call(this, parentVm)
     : parentVm[equalTo]

--- a/test/unit/specs/validators/sameAs.spec.js
+++ b/test/unit/specs/validators/sameAs.spec.js
@@ -6,14 +6,6 @@ describe('sameAs validator', () => {
     second: 'world'
   }
 
-  it('should validate empty string', () => {
-    expect(sameAs('second')('', parentVm)).to.be.true
-  })
-
-  it('should validate null', () => {
-    expect(sameAs('second')(null, parentVm)).to.be.true
-  })
-
   it('should not validate different string', () => {
     expect(sameAs('first')('world', parentVm)).to.be.false
     expect(sameAs('second')('hello', parentVm)).to.be.false


### PR DESCRIPTION
Fixes https://github.com/monterail/vuelidate/issues/65 and https://github.com/monterail/vuelidate/issues/66