### PR TITLE
Fix alpha, aplhaNum and numeric validators for undefined and null values

### DIFF
--- a/src/validators/alpha.js
+++ b/src/validators/alpha.js
@@ -1,1 +1,6 @@
-export default value => /^[a-zA-Z]*$/.test(value)
+export default value => {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return true
+  }
+  return /^[a-zA-Z]*$/.test(value)
+}

--- a/src/validators/alphaNum.js
+++ b/src/validators/alphaNum.js
@@ -1,1 +1,6 @@
-export default value => /^[a-zA-Z0-9]*$/.test(value)
+export default value => {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return true
+  }
+  return /^[a-zA-Z0-9]*$/.test(value)
+}

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -1,1 +1,6 @@
-export default value => /^[0-9]*$/.test(value)
+export default value => {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return true
+  }
+  return /^[0-9]*$/.test(value)
+}

--- a/test/unit/specs/validators/alpha.spec.js
+++ b/test/unit/specs/validators/alpha.spec.js
@@ -1,6 +1,10 @@
 import alpha from 'src/validators/alpha'
 
 describe('alpha validator', () => {
+  it('should validate null string', () => {
+    expect(alpha(null)).to.be.true
+  })
+
   it('should validate empty string', () => {
     expect(alpha('')).to.be.true
   })

--- a/test/unit/specs/validators/alphaNum.spec.js
+++ b/test/unit/specs/validators/alphaNum.spec.js
@@ -1,6 +1,10 @@
 import alphaNum from 'src/validators/alphaNum'
 
 describe('alphaNum validator', () => {
+  it('should validate null string', () => {
+    expect(alphaNum(null)).to.be.true
+  })
+
   it('should validate empty string', () => {
     expect(alphaNum('')).to.be.true
   })

--- a/test/unit/specs/validators/numeric.spec.js
+++ b/test/unit/specs/validators/numeric.spec.js
@@ -1,6 +1,10 @@
 import numeric from 'src/validators/numeric'
 
 describe('numeric validator', () => {
+  it('should validate null string', () => {
+    expect(numeric(null)).to.be.true
+  })
+
   it('should validate empty string', () => {
     expect(numeric('')).to.be.true
   })


### PR DESCRIPTION
required validator should be used for undefined, null and empty values.