### PR TITLE
[#117] fix too eager validation evaluation on $error access

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ const validationGetters = {
     })
   },
   $error () {
-    return !this.$pending && this.$dirty && this.$invalid
+    return this.$dirty && !this.$pending && this.$invalid
   },
   $pending () {
     const proxy = this.proxy

--- a/test/unit/specs/regression/#117-clean-error-evaluation.spec.js
+++ b/test/unit/specs/regression/#117-clean-error-evaluation.spec.js
@@ -1,0 +1,34 @@
+import Vue from 'vue'
+
+describe('#117 too eager evaluation', () => {
+  it('$error access should not trigger validation on clean field', () => {
+    const spy = sinon.stub().returns(true)
+    const vm = new Vue({
+      data: {
+        test: ''
+      },
+      validations: {
+        test: { spy }
+      }
+    })
+
+    expect(vm.$v.test.$error).to.be.false
+    expect(spy).to.not.have.been.called
+  })
+
+  it('$error access should trigger validation on dirty field', () => {
+    const spy = sinon.stub().returns(true)
+    const vm = new Vue({
+      data: {
+        test: ''
+      },
+      validations: {
+        test: { spy }
+      }
+    })
+
+    vm.$v.test.$touch()
+    expect(vm.$v.test.$error).to.be.false
+    expect(spy).to.have.been.calledOnce
+  })
+})


### PR DESCRIPTION
Inverses access order in $error to prefer $dirty check first, which avoids a dependency on validation output.

Fixes #117 