### PR TITLE
Fixed typo

### DIFF
--- a/docs/partials/_getting-started.pug
+++ b/docs/partials/_getting-started.pug
@@ -28,7 +28,7 @@
 
         var Component = Vue.extend({
           mixins: [validationMixin],
-          validation: { ... }
+          validations: { ... }
         })
     p.typo__p
       | If you prefer using <kbd>require</kbd>, it can be used instead of <kbd>import</kbd> statements.


### PR DESCRIPTION
Getting started section has typo. `validation` should be `validations`