### PR TITLE
Add get $errorMessage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ const validationMethods = {
         for (let j = 1; j < params.length; j++) {
           key = params[j].split(' ')[0]
           if (key === 'field') {
-            final = final.replace('|field', fieldName || validators[i]['name'] || '|field')
+            final = final.replace('|field', fieldName || this.prop || '|field')
           } else {
             final = final.replace('|' + key, validators[i]['params'][key] || '|' + key)
           }

--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ const validationMethods = {
           }
         }
 
-        return final.charAt(0).toUpperCase() + final.slice(1);
+        return final.charAt(0).toUpperCase() + final.slice(1)
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,12 +140,10 @@ const validationMethods = {
     if (this.$error === false) {
       return ''
     }
-
     messages = {
       ...defaultErrorMessage,
       ...messages
     }
-
     let validators = this.proxy.$flattenParams()
     let final = ''
     for (let i = 0; i < validators.length; i++) {
@@ -161,11 +159,9 @@ const validationMethods = {
             final = final.replace('|' + key, validators[i]['params'][key] || '|' + key)
           }
         }
-
         return final.charAt(0).toUpperCase() + final.slice(1)
       }
     }
-
     return 'ERROR'
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -114,28 +114,6 @@ function setDirtyRecursive (newState) {
 }
 
 const validationMethods = {
-  $touch () {
-    setDirtyRecursive.call(this, true)
-  },
-  $reset () {
-    setDirtyRecursive.call(this, false)
-  },
-  $flattenParams () {
-    const proxy = this.proxy
-    let params = []
-    for (const key in this.$params) {
-      if (this.isNested(key)) {
-        const childParams = proxy[key].$flattenParams()
-        for (let j = 0; j < childParams.length; j++) {
-          childParams[j].path.unshift(key)
-        }
-        params = params.concat(childParams)
-      } else {
-        params.push({ path: [], name: key, params: this.$params[key] })
-      }
-    }
-    return params
-  },
   $errorMessage (messages = {}, fieldName = null) {
     if (this.$error === false) {
       return ''
@@ -163,6 +141,28 @@ const validationMethods = {
       }
     }
     return 'ERROR'
+  },
+  $touch () {
+    setDirtyRecursive.call(this, true)
+  },
+  $reset () {
+    setDirtyRecursive.call(this, false)
+  },
+  $flattenParams () {
+    const proxy = this.proxy
+    let params = []
+    for (const key in this.$params) {
+      if (this.isNested(key)) {
+        const childParams = proxy[key].$flattenParams()
+        for (let j = 0; j < childParams.length; j++) {
+          childParams[j].path.unshift(key)
+        }
+        params = params.concat(childParams)
+      } else {
+        params.push({ path: [], name: key, params: this.$params[key] })
+      }
+    }
+    return params
   }
 }
 


### PR DESCRIPTION
Add method $errorMessage() in component, automatic generate error messages, can be use like this:

[Site Example](http://kahximiro.ddns.net/#/)

```
import { minLength, required, email } from 'vuelidate/lib/validators'

customMessages: {
  customEmail: '|field has error |dontHasParams(will be ignored)',
  minLength: 'Min |min digits',
}

validations: {
  form: {
    email: {
      required,
      customEmail: email,
      minLength: minLength(20)
    }
  }
}

customFieldName = 'Anything'

// Message 1º input
$v.form.email1.$errorMessage(customMessages, customFieldName)

// Message 2º input
$v.form.email2.$errorMessage()

// Message 3ºinput
$v.form.email3.$errorMessage({}, customFieldName

```
Already has default messages, and your default name is the name of the field.
This method return the first error message and works similar to "Laravel Validation".
Easy internationalization with customMessages.