### PR TITLE
Allow setting array to undefined and null when using $each

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -310,7 +310,7 @@ const getComponent = (Vue) => {
     computed: {
       keys () {
         var model = this.getModel()
-        if (isFunction(model) || (isObject(model) && model !== null)) {
+        if (isObject(model)) {
           return Object.keys(model)
         } else {
           return []

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,9 @@ const getComponent = (Vue) => {
   const EachValidation = Validation.extend({
     computed: {
       keys () {
-        return Object.keys(this.getModel())
+        var model = this.getModel()
+        if (model === undefined || model === null) return []
+        return Object.keys(model)
       },
       tracker () {
         const trackBy = this.validations.$trackBy

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,16 @@ const buildFromKeys = (keys, fn, keyFn) => keys.reduce((build, key) => {
   return build
 }, {})
 
+function isFunction (object) {
+  return typeof object === 'function'
+}
+
+function isObject (object) {
+  return typeof object === 'object'
+}
+
 function isPromise (object) {
-  return (typeof object === 'object' || typeof object === 'function') && typeof object.then === 'function'
+  return (isObject(object) || isFunction(object)) && isFunction(object.then)
 }
 
 const getPath = (ctx, obj, path, fallback) => {
@@ -302,10 +310,11 @@ const getComponent = (Vue) => {
     computed: {
       keys () {
         var model = this.getModel()
-        if (model === undefined || model === null) {
+        if (isFunction(model) || (isObject(model) && model !== null)) {
+          return Object.keys(model)
+        } else {
           return []
         }
-        return Object.keys(model)
       },
       tracker () {
         const trackBy = this.validations.$trackBy

--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,9 @@ const getComponent = (Vue) => {
     computed: {
       keys () {
         var model = this.getModel()
-        if (model === undefined || model === null) return []
+        if (model === undefined || model === null) {
+          return []
+        }
         return Object.keys(model)
       },
       tracker () {

--- a/src/index.js
+++ b/src/index.js
@@ -7,16 +7,16 @@ const buildFromKeys = (keys, fn, keyFn) => keys.reduce((build, key) => {
   return build
 }, {})
 
-function isFunction (object) {
-  return typeof object === 'function'
+function isFunction (val) {
+  return typeof val === 'function'
 }
 
-function isObject (object) {
-  return typeof object === 'object'
+function isObject (val) {
+  return val !== null && (typeof val === 'object' || isFunction(val))
 }
 
 function isPromise (object) {
-  return (isObject(object) || isFunction(object)) && isFunction(object.then)
+  return isObject(object) && isFunction(object.then)
 }
 
 const getPath = (ctx, obj, path, fallback) => {

--- a/test/unit/specs/validation.spec.js
+++ b/test/unit/specs/validation.spec.js
@@ -580,6 +580,8 @@ describe('Validation plugin', () => {
       expect(vm.$v.list.$invalid).to.be.false
       vm.list = 1
       expect(vm.$v.list.$invalid).to.be.false
+      vm.list = function () {}
+      expect(vm.$v.list.$invalid).to.be.false
       vm.list = [{value: 2}]
       expect(vm.$v.list.$invalid).to.be.false
       expect(vm.$v.list.$each[0]).to.exist

--- a/test/unit/specs/validation.spec.js
+++ b/test/unit/specs/validation.spec.js
@@ -571,11 +571,17 @@ describe('Validation plugin', () => {
     it('should allow changing the array to a non array value and back', () => {
       const vm = new Vue(vmDef(isEven))
       vm.list = undefined
+      expect(vm.$v.list.$invalid).to.be.false
       vm.list = null
+      expect(vm.$v.list.$invalid).to.be.false
       vm.list = false
+      expect(vm.$v.list.$invalid).to.be.false
       vm.list = ''
+      expect(vm.$v.list.$invalid).to.be.false
       vm.list = 1
-      vm.list = [{value: 1}]
+      expect(vm.$v.list.$invalid).to.be.false
+      vm.list = [{value: 2}]
+      expect(vm.$v.list.$invalid).to.be.false
       expect(vm.$v.list.$each[0]).to.exist
       expect(vm.$v.list.$each[1]).to.not.exist
     })

--- a/test/unit/specs/validation.spec.js
+++ b/test/unit/specs/validation.spec.js
@@ -568,6 +568,17 @@ describe('Validation plugin', () => {
       }
     })
 
+    it('should allow changing the array to a non array value and back', () => {
+      const vm = new Vue(vmDef(isEven))
+      vm.list = undefined
+      vm.list = null
+      vm.list = false
+      vm.list = ''
+      vm.list = 1
+      vm.list = [{value: 1}]
+      expect(vm.$v.list.$each[0]).to.exist
+      expect(vm.$v.list.$each[1]).to.not.exist
+    })
     it('should create validators for list items', () => {
       const vm = new Vue(vmDef(isEven))
       expect(vm.$v.list.$each[0]).to.exist


### PR DESCRIPTION
https://jsfiddle.net/b5v4faqf/358/

It fails here: https://github.com/monterail/vuelidate/blob/master/src/index.js#L304

Since calling Object.keys on undefined or null throws.
```
 TypeError: Cannot convert undefined or null to object
      at Function.keys (<anonymous>)
      at VueComponent.keys (node_modules\vuelidate\lib\index.js:351:23)
```

Haven't been able to clone and test your code locally yet due to some computer problems, but in my code this solution behaves as expected. So just relying on circleci to run the tests for me.
