### PR TITLE
Do not fail if parent object is non object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,10 @@ const getComponent = (Vue) => {
         return this.lazyModel ? this.lazyModel(this.prop) : this.model
       },
       getModelKey (key) {
-        return this.getModel()[key]
+        var model = this.getModel()
+        if (model) {
+          return model[key]
+        }
       }
     },
     computed: {

--- a/test/unit/specs/validation.spec.js
+++ b/test/unit/specs/validation.spec.js
@@ -9,6 +9,8 @@ const isOdd = withParams({ type: 'isOdd' }, (v) => {
   return v % 2 === 1
 })
 
+const noUndef = withParams({type: 'noUndef'}, (v) => v !== undefined)
+
 const T = () => true
 const F = () => false
 
@@ -586,6 +588,42 @@ describe('Validation plugin', () => {
       expect(vm.$v.list.$invalid).to.be.false
       expect(vm.$v.list.$each[0]).to.exist
       expect(vm.$v.list.$each[1]).to.not.exist
+    })
+    it('should allow parent object to be non object', function () {
+      const vm = new Vue({
+        data () {
+          return {
+            obj: {
+              value: 1
+            }
+          }
+        },
+        validations: {
+          obj: {
+            value: {
+              noUndef
+            }
+          }
+        }
+      })
+      vm.obj = undefined
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = null
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = false
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = 1
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = 'string'
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = function () {}
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = []
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = {}
+      expect(vm.$v.obj.$invalid).to.be.true
+      vm.obj = {value: 1}
+      expect(vm.$v.obj.$invalid).to.be.false
     })
     it('should create validators for list items', () => {
       const vm = new Vue(vmDef(isEven))


### PR DESCRIPTION
Similar to https://github.com/monterail/vuelidate/pull/204 vuelidate fails when parent object is set to non object. Without this fix vuelidate will fail in the test I wrote, trying to access key from undefined.