### PR TITLE
Improve numeric validator

### DIFF
--- a/docs/partials/validators/_validators.pug
+++ b/docs/partials/validators/_validators.pug
@@ -79,6 +79,10 @@ mixin validatorRow(validator, params)
               | Accepts only alphanumerics.
             +validatorRow('numeric')
               | Accepts only numerics.
+            +validatorRow('integer')
+              | Accepts positive and negative integers.
+            +validatorRow('decimal')
+              | Accepts positive and negative decimal numbers.
             +validatorRow('email')
               | Accepts valid email addresses. Keep in mind you still have to carefully verify it on your server,
               | as it is impossible to tell if the address is real without sending verification email.

--- a/src/validators/decimal.js
+++ b/src/validators/decimal.js
@@ -1,2 +1,2 @@
 import { regex } from './common'
-export default regex('numeric', /^-?[0-9.]*$/)
+export default regex('decimal', /^[-]?\d*(\.\d+)?$/)

--- a/src/validators/decimal.js
+++ b/src/validators/decimal.js
@@ -1,0 +1,2 @@
+import { regex } from './common'
+export default regex('numeric', /^-?[0-9.]*$/)

--- a/src/validators/integer.js
+++ b/src/validators/integer.js
@@ -1,0 +1,2 @@
+import { regex } from './common'
+export default regex('integer', /^-?[0-9]*$/)

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -1,2 +1,2 @@
-import {regex} from './common'
-export default regex('numeric', /^[0-9]*$/)
+import { regex } from './common'
+export default regex('numeric', /^-?[0-9.]*$/)

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -1,2 +1,2 @@
 import { regex } from './common'
-export default regex('numeric', /^-?[0-9.]*$/)
+export default regex('numeric', /^[0-9]*$/)

--- a/test/unit/specs/validators/decimal.spec.js
+++ b/test/unit/specs/validators/decimal.spec.js
@@ -53,4 +53,17 @@ describe('decimal validator', () => {
   it('should validate negative decimal numbers', () => {
     expect(decimal('-123.4')).to.be.true
   })
+
+  it('should not validate multiple decimal points', () => {
+    expect(decimal('-123.4.')).to.be.false
+    expect(decimal('..')).to.be.false
+  })
+
+  it('should validate decimal numbers without leading digits', () => {
+    expect(decimal('.1')).to.be.true
+  })
+
+  it('should not validate decimal numbers without trailing digits', () => {
+    expect(decimal('1.')).to.be.false
+  })
 })

--- a/test/unit/specs/validators/decimal.spec.js
+++ b/test/unit/specs/validators/decimal.spec.js
@@ -1,0 +1,56 @@
+import decimal from 'src/validators/decimal'
+
+describe('decimal validator', () => {
+  it('should validate undefined', () => {
+    expect(decimal(undefined)).to.be.true
+  })
+
+  it('should validate null', () => {
+    expect(decimal(null)).to.be.true
+  })
+
+  it('should validate empty string', () => {
+    expect(decimal('')).to.be.true
+  })
+
+  it('should validate numbers', () => {
+    expect(decimal('01234')).to.be.true
+  })
+
+  it('should not validate space', () => {
+    expect(decimal(' ')).to.be.false
+  })
+
+  it('should not validate english letters', () => {
+    expect(decimal('abcdefghijklmnopqrstuvwxyz')).to.be.false
+  })
+
+  it('should not validate english letters uppercase', () => {
+    expect(decimal('ABCDEFGHIJKLMNOPQRSTUVWXYZ')).to.be.false
+  })
+
+  it('should not validate alphanum', () => {
+    expect(decimal('abc123')).to.be.false
+  })
+
+  it('should not validate padded letters', () => {
+    expect(decimal(' 123 ')).to.be.false
+  })
+
+  it('should not validate unicode', () => {
+    expect(decimal('🎉')).to.be.false
+  })
+
+  it('should validate negative numbers', () => {
+    expect(decimal('-123')).to.be.true
+  })
+
+  it('should validate decimal numbers', () => {
+    expect(decimal('0.1')).to.be.true
+    expect(decimal('1.0')).to.be.true
+  })
+
+  it('should validate negative decimal numbers', () => {
+    expect(decimal('-123.4')).to.be.true
+  })
+})

--- a/test/unit/specs/validators/integer.js
+++ b/test/unit/specs/validators/integer.js
@@ -1,2 +1,0 @@
-import { regex } from './common'
-export default regex('integer', /^-?[0-9]*$/)

--- a/test/unit/specs/validators/integer.js
+++ b/test/unit/specs/validators/integer.js
@@ -1,0 +1,2 @@
+import { regex } from './common'
+export default regex('integer', /^-?[0-9]*$/)

--- a/test/unit/specs/validators/integer.spec.js
+++ b/test/unit/specs/validators/integer.spec.js
@@ -1,0 +1,56 @@
+import integer from 'src/validators/integer'
+
+describe('integer validator', () => {
+  it('should validate undefined', () => {
+    expect(integer(undefined)).to.be.true
+  })
+
+  it('should validate null', () => {
+    expect(integer(null)).to.be.true
+  })
+
+  it('should validate empty string', () => {
+    expect(integer('')).to.be.true
+  })
+
+  it('should validate numbers', () => {
+    expect(integer('01234')).to.be.true
+  })
+
+  it('should not validate space', () => {
+    expect(integer(' ')).to.be.false
+  })
+
+  it('should not validate english letters', () => {
+    expect(integer('abcdefghijklmnopqrstuvwxyz')).to.be.false
+  })
+
+  it('should not validate english letters uppercase', () => {
+    expect(integer('ABCDEFGHIJKLMNOPQRSTUVWXYZ')).to.be.false
+  })
+
+  it('should not validate alphanum', () => {
+    expect(integer('abc123')).to.be.false
+  })
+
+  it('should not validate padded letters', () => {
+    expect(integer(' 123 ')).to.be.false
+  })
+
+  it('should not validate unicode', () => {
+    expect(integer('🎉')).to.be.false
+  })
+
+  it('should validate negative numbers', () => {
+    expect(integer('-123')).to.be.true
+  })
+
+  it('should not validate decimal numbers', () => {
+    expect(integer('0.1')).to.be.false
+    expect(integer('1.0')).to.be.false
+  })
+
+  it('should not validate negative decimal numbers', () => {
+    expect(integer('-123.4')).to.be.false
+  })
+})

--- a/test/unit/specs/validators/numeric.spec.js
+++ b/test/unit/specs/validators/numeric.spec.js
@@ -30,7 +30,7 @@ describe('numeric validator', () => {
   })
 
   it('should not validate alphanum', () => {
-    expect(numeric('abc123')).to.be.falsesSt
+    expect(numeric('abc123')).to.be.false
   })
 
   it('should not validate padded letters', () => {

--- a/test/unit/specs/validators/numeric.spec.js
+++ b/test/unit/specs/validators/numeric.spec.js
@@ -30,7 +30,7 @@ describe('numeric validator', () => {
   })
 
   it('should not validate alphanum', () => {
-    expect(numeric('abc123')).to.be.false
+    expect(numeric('abc123')).to.be.falsesSt
   })
 
   it('should not validate padded letters', () => {
@@ -41,16 +41,16 @@ describe('numeric validator', () => {
     expect(numeric('🎉')).to.be.false
   })
 
-  it('should validate negative numbers', () => {
-    expect(numeric('-123')).to.be.true
+  it('should not validate negative numbers', () => {
+    expect(numeric('-123')).to.be.false
   })
 
-  it('should validate decimal numbers', () => {
-    expect(numeric('0.1')).to.be.true
-    expect(numeric('1.0')).to.be.true
+  it('should not validate decimal numbers', () => {
+    expect(numeric('0.1')).to.be.false
+    expect(numeric('1.0')).to.be.false
   })
 
-  it('should validate negative decimal numbers', () => {
-    expect(numeric('-123.4')).to.be.true
+  it('should not validate negative decimal numbers', () => {
+    expect(numeric('-123.4')).to.be.false
   })
 })

--- a/test/unit/specs/validators/numeric.spec.js
+++ b/test/unit/specs/validators/numeric.spec.js
@@ -40,4 +40,17 @@ describe('numeric validator', () => {
   it('should not validate unicode', () => {
     expect(numeric('🎉')).to.be.false
   })
+
+  it('should validate negative numbers', () => {
+    expect(numeric('-123')).to.be.true
+  })
+
+  it('should validate decimal numbers', () => {
+    expect(numeric('0.1')).to.be.true
+    expect(numeric('1.0')).to.be.true
+  })
+
+  it('should validate negative decimal numbers', () => {
+    expect(numeric('-123.4')).to.be.true
+  })
 })


### PR DESCRIPTION
As discussed in #136, numeric currently only accepts positive integer values. This pull request makes the following changes.

- Split numeric validator into numeric and integer validators.
- Update numeric validator to allow positive and negative decimal numbers.
- Limit integer validator to positive or negative whole numbers.
- Numeric validator still allows integers.
- Add unit tests for new validations.

