### PR TITLE
Update build scripts to enable development on Windows

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -46,7 +46,7 @@ module.exports = {
         test: /\.js$/,
         loader: 'eslint',
         include: projectRoot,
-        exclude: [/node_modules/, /docs\/assets/]
+        exclude: [/node_modules/, /docs[\\\/]assets/]
       }
     ],
     loaders: [

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "repository": "monterail/vuelidate",
   "scripts": {
     "dev": "node build/dev-server.js",
-    "bundle:web": "rm -rf dist && BUILD=web webpack --config build/webpack.bundle.conf.js",
-    "bundle:lib": "rm -rf lib && BUILD=lib babel src --out-dir lib",
+    "bundle:web": "rimraf dist && cross-env BUILD=web webpack --config build/webpack.bundle.conf.js",
+    "bundle:lib": "rimraf lib && cross-env BUILD=lib babel src --out-dir lib",
     "plugins": [
       "transform-inline-environment-variables"
     ],
     "build": "npm run bundle:lib && npm run bundle:web",
-    "docs": "rm -rf gh-pages && mkdir gh-pages && node build/build.js",
+    "docs": "rimraf gh-pages && mkdir gh-pages && node build/build.js",
     "unit": "karma start test/unit/karma.conf.js --watch",
     "test-unit": "karma start test/unit/karma.conf.js --single-run",
     "test-ssr": "mocha --compilers js:babel-core/register test/ssr/index.js",
@@ -41,6 +41,7 @@
     "chalk": "^1.1.3",
     "connect-history-api-fallback": "^1.1.0",
     "copy-webpack-plugin": "^4.0.0",
+    "cross-env": "^5.1.3",
     "css-loader": "^0.25.0",
     "eslint": "^3.7.1",
     "eslint-config-standard": "^6.1.0",
@@ -75,6 +76,7 @@
     "pug-loader": "^2.3.0",
     "puppeteer": "^0.13.0",
     "raw-loader": "^0.5.1",
+    "rimraf": "^2.6.2",
     "sass-loader": "^3.2.0",
     "semver": "^5.3.0",
     "shelljs": "^0.7.4",


### PR DESCRIPTION
This project does not currently build on a Windows environment as identified by @SirLamer in https://github.com/monterail/vuelidate/issues/136#issuecomment-298050082. These changes fix that.

- Add `cross-env` package to set environment variables, since `VAR=val` is invalid on Windows.
- Add `rimraf` package and use it instead of `rm -rf` which does not exist on Windows.
- Update the `exclude` path for eslint in `webpack.base.conf.js`, since Windows uses a different path delimiter.

