### PR TITLE
Add integer and decimal validators to index.js

### DIFF
--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -16,6 +16,8 @@ import or from './or'
 import and from './and'
 import minValue from './minValue'
 import maxValue from './maxValue'
+import integer from './integer'
+import decimal from './decimal'
 
 export {
   alpha,
@@ -35,5 +37,7 @@ export {
   or,
   and,
   minValue,
-  maxValue
+  maxValue,
+  integer,
+  decimal
 }


### PR DESCRIPTION
Forgot to add `integer` and `decimal` to `index.js` in this previous pull request https://github.com/monterail/vuelidate/pull/245