### PR TITLE
fix #301 - broken imports in node environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,21 +1,14 @@
 {
   "presets": [
     ["@babel/preset-env", {
-      "modules": false
+      "targets": {
+        "node": "6"
+      }
     }]
   ],
   "plugins": [
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-export-default-from"
   ],
-  "comments": false,
-  "env": {
-    "node": {
-      "presets": [
-        ["@babel/preset-env", {
-          "modules": "commonjs"
-        }]
-      ]
-    }
-  }
+  "comments": false
 }


### PR DESCRIPTION
this fixed #301 for me

the `env` condition in the `.babelrc` was never met, see [babel env option](https://babeljs.io/docs/usage/babelrc/#env-option)